### PR TITLE
add background color setting for non-paid comments

### DIFF
--- a/src/components/MessageTabItem.vue
+++ b/src/components/MessageTabItem.vue
@@ -151,6 +151,15 @@
         </template>
       </v-slider>
 
+      <div class="caption">Background Color</div>
+      <v-text-field
+        v-model="backgroundColor"
+        class="align-center mb-5"
+        dense
+        hide-details
+        single-line
+      />
+
       <div class="caption">Background Opacity (for Paid Messages)</div>
       <v-slider
         v-model="backgroundOpacity"
@@ -412,6 +421,16 @@ export default defineComponent({
         })
       },
     })
+    const backgroundColor = computed({
+      get: () => {
+        return settingsStore.backgroundColor
+      },
+      set: (value) => {
+        settingsStore.setBackgroundColor({
+          backgroundColor: value,
+        })
+      },
+    })
     const backgroundOpacity = computed({
       get: () => {
         return settingsStore.backgroundOpacity
@@ -512,6 +531,7 @@ export default defineComponent({
       maxWidth,
       lineHeight,
       opacity,
+      backgroundColor,
       backgroundOpacity,
       outlineRatio,
       extendedStyle,

--- a/src/components/MessageTabItem.vue
+++ b/src/components/MessageTabItem.vue
@@ -151,16 +151,10 @@
         </template>
       </v-slider>
 
-      <div class="caption">Background Color</div>
-      <v-text-field
-        v-model="backgroundColor"
-        class="align-center mb-5"
-        dense
-        hide-details
-        single-line
-      />
+      <div class="caption">Show Background (for Non-paid Messages)</div>
+      <v-switch v-model="background" class="mt-0" dense />
 
-      <div class="caption">Background Opacity (for Paid Messages)</div>
+      <div class="caption">Background Opacity</div>
       <v-slider
         v-model="backgroundOpacity"
         class="align-center mb-5"
@@ -421,13 +415,13 @@ export default defineComponent({
         })
       },
     })
-    const backgroundColor = computed({
+    const background = computed({
       get: () => {
-        return settingsStore.backgroundColor
+        return settingsStore.background
       },
       set: (value) => {
-        settingsStore.setBackgroundColor({
-          backgroundColor: value,
+        settingsStore.setBackground({
+          background: value,
         })
       },
     })
@@ -531,7 +525,7 @@ export default defineComponent({
       maxWidth,
       lineHeight,
       opacity,
-      backgroundColor,
+      background,
       backgroundOpacity,
       outlineRatio,
       extendedStyle,

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -26,6 +26,7 @@ export type Settings = {
   maxWidth: number
   lineHeight: number
   opacity: number
+  backgroundColor: string
   backgroundOpacity: number
   outlineRatio: number
   extendedStyle: string

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -26,7 +26,7 @@ export type Settings = {
   maxWidth: number
   lineHeight: number
   opacity: number
-  backgroundColor: string
+  background: boolean
   backgroundOpacity: number
   outlineRatio: number
   extendedStyle: string

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -56,7 +56,7 @@ const initialState: Omit<
   maxWidth: 100,
   lineHeight: 64,
   opacity: 0.8,
-  backgroundColor: 'transparent',
+  background: false,
   backgroundOpacity: 0.4,
   outlineRatio: 0.015,
   extendedStyle: '',
@@ -77,7 +77,7 @@ export default class SettingsModule extends VuexModule {
   maxWidth = initialState.maxWidth
   lineHeight = initialState.lineHeight
   opacity = initialState.opacity
-  backgroundColor = initialState.backgroundColor
+  background = initialState.background
   backgroundOpacity = initialState.backgroundOpacity
   outlineRatio = initialState.outlineRatio
   extendedStyle = initialState.extendedStyle
@@ -137,8 +137,8 @@ export default class SettingsModule extends VuexModule {
     this.opacity = opacity
   }
   @Mutation
-  setBackgroundColor({ backgroundColor }: { backgroundColor: string }): void {
-    this.backgroundColor = backgroundColor
+  setBackground({ background }: { background: boolean }): void {
+    this.background = background
   }
   @Mutation
   setBackgroundOpacity({

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -56,6 +56,7 @@ const initialState: Omit<
   maxWidth: 100,
   lineHeight: 64,
   opacity: 0.8,
+  backgroundColor: 'transparent',
   backgroundOpacity: 0.4,
   outlineRatio: 0.015,
   extendedStyle: '',
@@ -76,6 +77,7 @@ export default class SettingsModule extends VuexModule {
   maxWidth = initialState.maxWidth
   lineHeight = initialState.lineHeight
   opacity = initialState.opacity
+  backgroundColor = initialState.backgroundColor
   backgroundOpacity = initialState.backgroundOpacity
   outlineRatio = initialState.outlineRatio
   extendedStyle = initialState.extendedStyle
@@ -133,6 +135,10 @@ export default class SettingsModule extends VuexModule {
   @Mutation
   setOpacity({ opacity }: { opacity: number }): void {
     this.opacity = opacity
+  }
+  @Mutation
+  setBackgroundColor({ backgroundColor }: { backgroundColor: string }): void {
+    this.backgroundColor = backgroundColor
   }
   @Mutation
   setBackgroundOpacity({

--- a/src/utils/message-settings.ts
+++ b/src/utils/message-settings.ts
@@ -107,7 +107,7 @@ export default class MessageSettings {
 
   get backgroundColor(): string | undefined {
     if (!this.message.backgroundColor) {
-      return undefined
+      return this.settings.backgroundColor
     }
     try {
       const o = new Color(this.message.backgroundColor).object()

--- a/src/utils/message-settings.ts
+++ b/src/utils/message-settings.ts
@@ -106,11 +106,18 @@ export default class MessageSettings {
   }
 
   get backgroundColor(): string | undefined {
-    if (!this.message.backgroundColor) {
-      return this.settings.backgroundColor
+    const backgroundColor = this.paid
+      ? this.message.backgroundColor
+      : this.settings.background
+      ? 'black'
+      : undefined
+
+    if (!backgroundColor) {
+      return undefined
     }
+
     try {
-      const o = new Color(this.message.backgroundColor).object()
+      const o = new Color(backgroundColor).object()
       const opacity = this.settings.backgroundOpacity
       return `rgba(${o.r}, ${o.g}, ${o.b}, ${opacity})`
     } catch (e) {


### PR DESCRIPTION
通常のコメントの背景色を設定できるようにする機能提案です。以下の画像のように有料のコメントとは別に通常のコメントの背景色を設定できます。

コメントに黒背景をつけることで見やすくするための機能です。

![a](https://user-images.githubusercontent.com/574575/112159085-1c872280-8c2c-11eb-94ab-623a3927a4ea.png)

以下が設定画面です。設定画面のUIには改善の余地があると思います（カラーピッカーウィジェットを使うなど）。

![Screenshot 2021-03-23 22 36 39](https://user-images.githubusercontent.com/574575/112158752-cf0ab580-8c2b-11eb-997d-05eaa6e93e6a.png)
